### PR TITLE
supported symlink target.

### DIFF
--- a/cmd/cachectl/cachectl.go
+++ b/cmd/cachectl/cachectl.go
@@ -42,7 +42,7 @@ func main() {
 	re := regexp.MustCompile(*filter)
 
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		realPath, err := os.Readlink(fi.Name)
+		realPath, err := os.Readlink(fi.Name())
 		if err != nil {
 			log.Fatalf("failed to readlink: %s.", fi.Name())
 		}

--- a/cmd/cachectl/cachectl.go
+++ b/cmd/cachectl/cachectl.go
@@ -30,7 +30,7 @@ func main() {
 		return
 	}
 
-	fi, err := os.Stat(*fpath)
+	fi, err := os.Lstat(*fpath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func main() {
 	re := regexp.MustCompile(*filter)
 
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		realPath, err := os.Readlink(fi.Name())
+		realPath, err := os.Readlink(*fpath)
 		if err != nil {
 			log.Fatalf("failed to readlink: %s.", fi.Name())
 		}
@@ -50,6 +50,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		*fpath = realPath
 	}
 
 	if *op == "stat" {

--- a/cmd/cachectl/cachectl.go
+++ b/cmd/cachectl/cachectl.go
@@ -41,6 +41,17 @@ func main() {
 
 	re := regexp.MustCompile(*filter)
 
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		realPath, err := os.Readlink(fi.Name)
+		if err != nil {
+			log.Fatalf("failed to readlink: %s.", fi.Name())
+		}
+		fi, err = os.Stat(realPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if *op == "stat" {
 		if fi.IsDir() {
 			err := cachectl.WalkPrintPagesStat(*fpath, re)

--- a/cmd/cachectld/cachectld.go
+++ b/cmd/cachectld/cachectld.go
@@ -20,7 +20,7 @@ func purgePages(target cachectl.SectionTarget, re *regexp.Regexp) error {
 	}
 
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		realPath, err := os.Readlink(fi.Name)
+		realPath, err := os.Readlink(fi.Name())
 		if err != nil {
 			return err
 		}

--- a/cmd/cachectld/cachectld.go
+++ b/cmd/cachectld/cachectld.go
@@ -14,13 +14,13 @@ import (
 )
 
 func purgePages(target cachectl.SectionTarget, re *regexp.Regexp) error {
-	fi, err := os.Stat(target.Path)
+	fi, err := os.Lstat(target.Path)
 	if err != nil {
 		return err
 	}
 
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		realPath, err := os.Readlink(fi.Name())
+		realPath, err := os.Readlink(target.Path)
 		if err != nil {
 			return err
 		}
@@ -28,6 +28,7 @@ func purgePages(target cachectl.SectionTarget, re *regexp.Regexp) error {
 		if err != nil {
 			return err
 		}
+		target.Path = realPath
 	}
 
 	verbose := false

--- a/cmd/cachectld/cachectld.go
+++ b/cmd/cachectld/cachectld.go
@@ -19,6 +19,17 @@ func purgePages(target cachectl.SectionTarget, re *regexp.Regexp) error {
 		return err
 	}
 
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		realPath, err := os.Readlink(fi.Name)
+		if err != nil {
+			return err
+		}
+		fi, err = os.Stat(realPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	verbose := false
 
 	if fi.IsDir() {


### PR DESCRIPTION
Previously cachectl did not walk directory if target is symlink.