### PR TITLE
prevent panic in filepath.walk

### DIFF
--- a/cachectl/walk.go
+++ b/cachectl/walk.go
@@ -10,6 +10,10 @@ import (
 func WalkPrintPagesStat(path string, re *regexp.Regexp) error {
 	return filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Println(err.Error())
+				return nil
+			}
 			if !info.Mode().IsRegular() {
 				return nil
 			}
@@ -24,6 +28,10 @@ func WalkPrintPagesStat(path string, re *regexp.Regexp) error {
 func WalkPurgePages(path string, re *regexp.Regexp, rate float64, verbose bool) error {
 	return filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Println(err.Error())
+				return nil
+			}
 			if !info.Mode().IsRegular() {
 				return nil
 			}


### PR DESCRIPTION
panic in filepath.walk

```
[2020-12-08T02:15:12][136657] panic: runtime error: invalid memory address or nil pointer dereference
[2020-12-08T02:15:12][136657] [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x4cf7bc]
[2020-12-08T02:15:12][136657]
[2020-12-08T02:15:12][136657] goroutine 1 [running]:
[2020-12-08T02:15:12][136657] github.com/cubicdaiya/cachectl/cachectl.WalkPurgePages.func1(0xc000116de0, 0x55, 0x0, 0x0, 0x533160, 0xc000118360, 0x0, 0x0)
[2020-12-08T02:15:12][136657]     /root/.go/src/github.com/cubicdaiya/cachectl/cachectl/walk.go:27 +0x5c
[2020-12-08T02:15:12][136657] path/filepath.walk(0xc00012e330, 0x27, 0x5343c0, 0xc0001235f0, 0xc000159e58, 0x0, 0x0)
[2020-12-08T02:15:12][136657]     /usr/local/go/src/path/filepath/path.go:378 +0x20c
[2020-12-08T02:15:12][136657] path/filepath.walk(0x7ffea49faedd, 0x15, 0x5343c0, 0xc000122a90, 0xc000159e58, 0x0, 0x511c99)
[2020-12-08T02:15:12][136657]     /usr/local/go/src/path/filepath/path.go:382 +0x2ff
[2020-12-08T02:15:12][136657] path/filepath.Walk(0x7ffea49faedd, 0x15, 0xc00011ee58, 0x7ffea49faedd, 0x15)
[2020-12-08T02:15:12][136657]     /usr/local/go/src/path/filepath/path.go:404 +0xff
[2020-12-08T02:15:12][136657] github.com/cubicdaiya/cachectl/cachectl.WalkPurgePages(0x7ffea49faedd, 0x15, 0xc0001341e0, 0x3ff0000000000000, 0x0, 0x0, 0xc000016098)
[2020-12-08T02:15:12][136657]     /root/.go/src/github.com/cubicdaiya/cachectl/cachectl/walk.go:25 +0x84
[2020-12-08T02:15:12][136657] main.main()
[2020-12-08T02:15:12][136657]     /root/.go/src/github.com/cubicdaiya/cachectl/cmd/cachectl/cachectl.go:71 +0x41e
[2020-12-08T02:15:12][136657] command exited with code:2
```